### PR TITLE
Fix compilation for 64bit souffle wordsizes, add build and test action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,9 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-test:
-
-    runs-on: ubuntu-latest
+  build-and-test(32bit):
+    # Souffle with a 32bit word size is built inside our "Gigahorse dependencies" docker image
+    runs-on: ubuntu-22.04
 
     container:
       image: ghcr.io/nevillegrech/gigahorse-toolchain-deps-souffle24:latest
@@ -29,8 +29,8 @@ jobs:
     - name: Run smt-testing.dl
       run: souffle smt-testing.dl
 
-  build-and-test-with-package:
-
+  build-and-test(64bit):
+    # Souffle with a 64bit word size is installed on the runner via the provided .deb files
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 
@@ -20,3 +20,7 @@ jobs:
       run: make libsoufflenum.so
     - name: Test
       run: make
+    - name: Run lists_test.dl
+      run: souffle lists_test.dl
+    - name: Run smt-testing.dl
+      run: souffle smt-testing.dl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
 
   build-and-test-with-package:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,22 @@
+name: Build and Test Functors
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/nevillegrech/gigahorse-toolchain-deps-souffle24:latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: make libsoufflenum.so
+    - name: Test
+      run: make

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-test-32bit-word:
+  build-and-test-32bit-wordsize:
     # Souffle with a 32bit word size is built inside our "Gigahorse dependencies" docker image
     runs-on: ubuntu-22.04
 
@@ -29,7 +29,7 @@ jobs:
     - name: Run smt-testing.dl
       run: souffle smt-testing.dl
 
-  build-and-test-64bit-word:
+  build-and-test-64bit-wordsize:
     # Souffle with a 64bit word size is installed on the runner via the provided .deb files
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Test Souffle
+      run: souffle --version
+
     - name: Build
       run: make libsoufflenum.so
     - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,20 +32,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Souffle
-      run: |
-        sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-        sudo apt update && sudo apt install souffle=2.3
+    - name: Download souffle
+      run: wget -O souffle.deb https://github.com/souffle-lang/souffle/releases/download/2.4.1/x86_64-ubuntu-2004-souffle-2.4.1-Linux.deb
+    - name: Install souffle
+      run: sudo apt-get install ./souffle.deb -y
 
     - name: Test Souffle
       run: souffle --version
 
     - name: Install Boost
       run: sudo apt install libboost-all-dev
-
-    - name: Install z3
-      run: sudo apt install libz3-dev z3
 
     - name: Build
       run: make libsoufflenum.so

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-test(32bit):
+  build-and-test-32bit-word:
     # Souffle with a 32bit word size is built inside our "Gigahorse dependencies" docker image
     runs-on: ubuntu-22.04
 
@@ -29,7 +29,7 @@ jobs:
     - name: Run smt-testing.dl
       run: souffle smt-testing.dl
 
-  build-and-test(64bit):
+  build-and-test-64bit-word:
     # Souffle with a 64bit word size is installed on the runner via the provided .deb files
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
       run: sudo apt install libboost-all-dev
 
     - name: Install z3
-      run: sudo apt install libz3-dev
+      run: sudo apt install libz3-dev z3
 
     - name: Build
       run: make libsoufflenum.so

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
 
   build-and-test-with-package:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -43,6 +43,9 @@ jobs:
 
     - name: Install Boost
       run: sudo apt install libboost-all-dev
+
+    - name: Install z3
+      run: sudo apt install libz3-dev
 
     - name: Build
       run: make libsoufflenum.so

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
         echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-        sudo apt update && sudo apt install souffle=2.4
+        sudo apt update && sudo apt install souffle=2.3
 
     - name: Test Souffle
       run: souffle --version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,9 +21,9 @@ jobs:
       run: souffle --version
 
     - name: Build
-      run: make libsoufflenum.so
+      run: make libsoufflenum.so WORD_SIZE=$(souffle --version | sed -n 3p | cut -c12,13)
     - name: Test
-      run: make
+      run: make WORD_SIZE=$(souffle --version | sed -n 3p | cut -c12,13)
     - name: Run lists_test.dl
       run: souffle lists_test.dl
     - name: Run smt-testing.dl
@@ -48,9 +48,9 @@ jobs:
       run: sudo apt install libboost-all-dev
 
     - name: Build
-      run: make libsoufflenum.so
+      run: make libsoufflenum.so WORD_SIZE=$(souffle --version | sed -n 3p | cut -c12,13)
     - name: Test
-      run: make
+      run: make WORD_SIZE=$(souffle --version | sed -n 3p | cut -c12,13)
     - name: Run lists_test.dl
       run: souffle lists_test.dl
     - name: Run smt-testing.dl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,3 +24,31 @@ jobs:
       run: souffle lists_test.dl
     - name: Run smt-testing.dl
       run: souffle smt-testing.dl
+
+  build-and-test-with-package:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Souffle
+      run: |
+        sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
+        sudo apt update && sudo apt install souffle=2.4
+
+    - name: Test Souffle
+      run: souffle --version
+
+    - name: Install Boost
+      run: sudo apt install libboost-all-dev
+
+    - name: Build
+      run: make libsoufflenum.so
+    - name: Test
+      run: make
+    - name: Run lists_test.dl
+      run: souffle lists_test.dl
+    - name: Run smt-testing.dl
+      run: souffle smt-testing.dl

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 KECCAK_DIR := keccak
 KECCAK_SRC := $(wildcard $(KECCAK_DIR)/*.c)
 KECCAK_OBJ := $(patsubst $(KECCAK_DIR)/%.c,$(KECCAK_DIR)/%.o, $(KECCAK_SRC))
+WORD_SIZE=32
 
 .PHONY: clean softclean
 
@@ -8,41 +9,41 @@ KECCAK_OBJ := $(patsubst $(KECCAK_DIR)/%.c,$(KECCAK_DIR)/%.o, $(KECCAK_SRC))
 all: libsoufflenum.so num_tests mappings_tests keccak256_tests
 
 libsoufflenum.so: $(KECCAK_OBJ) num256.o mappings.o keccak256.o lists.o smt-api.o
-	g++ -std=c++17 -shared -o libsoufflenum.so $(KECCAK_OBJ) smt-api.o num256.o mappings.o keccak256.o lists.o -march=native -lz3 -fopenmp
-	ln -sf libsoufflenum.so libfunctors.so 
+	g++ -std=c++17 -shared -o libsoufflenum.so $(KECCAK_OBJ) smt-api.o num256.o mappings.o keccak256.o lists.o -march=native -lz3 -fopenmp -DRAM_DOMAIN_SIZE=$(WORD_SIZE)
+	ln -sf libsoufflenum.so libfunctors.so
 
 smt-api.o: smt-api.cpp
-	g++ -std=c++17  smt-api.cpp -lz3 -fopenmp -c -fPIC -o smt-api.o
+	g++ -std=c++17  smt-api.cpp -lz3 -fopenmp -DRAM_DOMAIN_SIZE=$(WORD_SIZE) -c -fPIC -o smt-api.o
 
 num256.o: num256.cpp
 	g++ -std=c++17 -O2 num256.cpp -c -fPIC -o num256.o -lz3 -fopenmp
 
 num_tests:	num256.cpp num256_test.cpp 
-	g++ -std=c++17 -o num_tests num256_test.cpp -fopenmp
+	g++ -std=c++17 -o num_tests num256_test.cpp
 	./num_tests
 
 mappings.o: mappings.cpp
 	g++ -std=c++17 -O2 mappings.cpp -c -fPIC -o mappings.o -lz3 -fopenmp
 
 mappings_tests:	mappings.cpp mappings_test.cpp
-	g++ -std=c++17 -o mappings_tests mappings_test.cpp -fopenmp
+	g++ -std=c++17 -o mappings_tests mappings_test.cpp
 	./mappings_tests
 
 lists.o: lists.cpp
-	g++ -std=c++17 -O2 lists.cpp -c -fPIC -o lists.o -lz3 -fopenmp
+	g++ -std=c++17 -O2 lists.cpp -c -fPIC -o lists.o -lz3 -fopenmp -DRAM_DOMAIN_SIZE=$(WORD_SIZE)
 
 lists_tests:	lists.cpp lists_test.cpp
-	g++ -std=c++17 -o lists_tests lists_test.cpp -fopenmp
+	g++ -std=c++17 -o lists_tests lists_test.cpp
 	./lists_tests
 
 keccak256.o: keccak256.cpp
 	g++ -std=c++17 -O2 keccak256.cpp -c -fPIC -o keccak256.o -fopenmp
 
 keccak256_test.o: keccak256_test.cpp keccak256.cpp
-	g++ -std=c++17 -O2 -c -o keccak256_test.o keccak256_test.cpp -fopenmp
+	g++ -std=c++17 -O2 -c -o keccak256_test.o keccak256_test.cpp
 
 keccak256_tests: keccak256_test.o $(KECCAK_OBJ)
-	g++ -std=c++17 keccak256_test.o $(KECCAK_OBJ) -o keccak256_tests -fopenmp
+	g++ -std=c++17 keccak256_test.o $(KECCAK_OBJ) -o keccak256_tests
 	./keccak256_tests
 
 $(KECCAK_DIR)/%.o: $(KECCAK_DIR)/%.c $(KECCAK_SRC)

--- a/Makefile
+++ b/Makefile
@@ -8,45 +8,45 @@ KECCAK_OBJ := $(patsubst $(KECCAK_DIR)/%.c,$(KECCAK_DIR)/%.o, $(KECCAK_SRC))
 all: libsoufflenum.so num_tests mappings_tests keccak256_tests
 
 libsoufflenum.so: $(KECCAK_OBJ) num256.o mappings.o keccak256.o lists.o smt-api.o
-	g++ -std=c++17 -shared -o libsoufflenum.so $(KECCAK_OBJ) smt-api.o num256.o mappings.o keccak256.o lists.o -march=native -lz3
+	g++ -std=c++17 -shared -o libsoufflenum.so $(KECCAK_OBJ) smt-api.o num256.o mappings.o keccak256.o lists.o -march=native -lz3 -fopenmp
 	ln -sf libsoufflenum.so libfunctors.so 
 
 smt-api.o: smt-api.cpp
-	g++ -std=c++17  smt-api.cpp -lz3 -c -fPIC -o smt-api.o
+	g++ -std=c++17  smt-api.cpp -lz3 -fopenmp -c -fPIC -o smt-api.o
 
 num256.o: num256.cpp
-	g++ -std=c++17 -O2 num256.cpp -c -fPIC -o num256.o -lz3
+	g++ -std=c++17 -O2 num256.cpp -c -fPIC -o num256.o -lz3 -fopenmp
 
 num_tests:	num256.cpp num256_test.cpp 
-	g++ -std=c++17 -o num_tests num256_test.cpp
+	g++ -std=c++17 -o num_tests num256_test.cpp -fopenmp
 	./num_tests
 
 mappings.o: mappings.cpp
-	g++ -std=c++17 -O2 mappings.cpp -c -fPIC -o mappings.o -lz3
+	g++ -std=c++17 -O2 mappings.cpp -c -fPIC -o mappings.o -lz3 -fopenmp
 
 mappings_tests:	mappings.cpp mappings_test.cpp
-	g++ -std=c++17 -o mappings_tests mappings_test.cpp
+	g++ -std=c++17 -o mappings_tests mappings_test.cpp -fopenmp
 	./mappings_tests
 
 lists.o: lists.cpp
-	g++ -std=c++17 -O2 lists.cpp -c -fPIC -o lists.o -lz3
+	g++ -std=c++17 -O2 lists.cpp -c -fPIC -o lists.o -lz3 -fopenmp
 
 lists_tests:	lists.cpp lists_test.cpp
-	g++ -std=c++17 -o lists_tests lists_test.cpp
+	g++ -std=c++17 -o lists_tests lists_test.cpp -fopenmp
 	./lists_tests
 
 keccak256.o: keccak256.cpp
-	g++ -std=c++17 -O2 keccak256.cpp -c -fPIC -o keccak256.o
+	g++ -std=c++17 -O2 keccak256.cpp -c -fPIC -o keccak256.o -fopenmp
 
 keccak256_test.o: keccak256_test.cpp keccak256.cpp
-	g++ -std=c++17 -O2 -c -o keccak256_test.o keccak256_test.cpp
+	g++ -std=c++17 -O2 -c -o keccak256_test.o keccak256_test.cpp -fopenmp
 
 keccak256_tests: keccak256_test.o $(KECCAK_OBJ)
-	g++ -std=c++17 keccak256_test.o $(KECCAK_OBJ) -o keccak256_tests
+	g++ -std=c++17 keccak256_test.o $(KECCAK_OBJ) -o keccak256_tests -fopenmp
 	./keccak256_tests
 
 $(KECCAK_DIR)/%.o: $(KECCAK_DIR)/%.c $(KECCAK_SRC)
-	gcc -O2 -c -fPIC -o $@ $<
+	gcc -O2 -fopenmp -c -fPIC -o $@ $<
 
 softclean:
 	rm -f $(KECCAK_OBJ)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ Dependencies:
  - Boost libraries
  - Z3: https://github.com/Z3Prover/z3
 
+Functor compilation is rellying on the underlying word size of the installed `souffle` binary.
+Due to that, our Makefile is parametrized via its `WORD_SIZE` parameter.
+The `make WORD_SIZE=$(souffle --version | sed -n 3p | cut -c12,13)` command will build the functor with the correct word size (for latest `souffle` versions). 
 Usage:
 
-    $ make                          # builds all, sets libfunctors.so as a link to libsoufflenum.so
+    $ make WORD_SIZE=32|64          # builds all, sets libfunctors.so as a link to libsoufflenum.so
     $ export LD_LIBRARY_PATH=`pwd`  # or wherever you want to put the resulting libfunctors.so
 
 and use a Souffle program with the num256functors.dl definitions. For compiled execution, libfunctors.so (i.e., at least a

--- a/lists_test.dl
+++ b/lists_test.dl
@@ -37,3 +37,9 @@ TestAppend(a, b, @list_append(a, b)):-
   a = ["0x8d8", ["0xf48", ["0xd05", ["0xd4b", ["0x91d", nil]]]]],
   b = "0x1457",
   @list_append(a, b) =  ["0x8d8", ["0xf48", ["0xd05", ["0xd4b", ["0x91d", ["0x1457", nil]]]]]].
+
+.decl BreakSouffle(x:StringList)
+BreakSouffle(["ddd", nil]).
+BreakSouffle(@list_append(["ddd", nil], "ddd")) :- BreakSouffle(["ddd", nil]).
+
+.output BreakSouffle


### PR DESCRIPTION
Fixed compilation for souffle binaries with a 64 bit word size.
Added action that builds and tests basic functor functionality with both 32bit and 64bit souffle wordsizes.